### PR TITLE
Add config for allowable chars

### DIFF
--- a/classes/search.php
+++ b/classes/search.php
@@ -205,6 +205,7 @@ class Search
         $words = self::split_string($txt, array(
             'min_word_len' => $this->config['min_word_len'],
             'forbidden_words' => $this->config['forbidden_words'],
+            'allowable_chars' => $this->config['allowable_chars'],
         ));
 
         $i = 0;


### PR DESCRIPTION
Allowed  characters to not split words . Search specifics words :
Ref of an article for exemple : 1234f.dfrredd (no split with the .)
